### PR TITLE
Improvement of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,39 @@ Install via the Plugin Manager or manually using this URL:
 
 ## Configuration
 
-- Once installed your Tasmota devices will need to have the FullTopic configured as **%topic%/%prefix%/**
-- Use the Tasmota device's topic in the Tasmota-MQTT Plugin settings for the individual relays.
-- For multiple relay devices enter the index number that matches your desired relay.
-- For single relay devices like the [iTead Sonoff S20 Smart Socket](https://www.itead.cc/smart-socket.html), leave Relay # blank.
-- Full Topic in plugin settings must match your relay's `Full Topic` pattern.
+- Once installed you need to configure the "Full Topic" EXACTLY the same way like in your Tasmota devices. It can be found at the Tasmota device web-service page under information. Copy it over to make sure it is identical. E.g., **%topic%/%prefix%/**
+- add a Relay device and configure
+ - **Topic:** is the name of the Tasmota device
+ - **Relay #:** For multiple relay devices enter the index number that matches your desired relay. For single relay devices like the [iTead Sonoff S20 Smart Socket](https://www.itead.cc/smart-socket.html), leave it blank.
+ - **Icon class:** lets you select the icon to be shown on the front page.
+ - **Warning Prompt:** Issues always an addtional warning to avoid accidentally switching.
+ - **Warn While Printing:** Issues an addtional warning only if a print is in progress. 
+ - **Auto Connect:** Connect to the printer N seconds after power was switched on. The time delays can help to establish a stable connection. 	
+ - **Auto Disconnect:** Disconnects the printer N seconds prior of switching off the power.  
+ - **GCODE Trigger:** Enable the switching via M80 and M81 code. See below.
+ - **GCODE On Delay:** Time delay in seconds after receiving M80 before switching on.
+ - **GCODE Off Delay:** Time delay in seconds after receving M81 before switching off. 
+ - **Run System Command After On:** Issue a system command after switching on. 
+ - **Run System Command Before Off:** Issue a system command after switching off.
+### GCODE config
+If GCODE Trigger is switched on, the plugin looks out for Gcode to switch the relay on resp. off. This can be used to switch the printer on at the start of a print and off right after a print is finished. The delay times can be used to e.g. to let the printer powered on for a certain time after the print is finished e.g. to let fans running helping to cool down quicker.
+
+The usual format of the GCODE which performs the trigger of the relay is:
+
+**M80|M81 TOPIC RELAY#**
+
+Explanation:
+- M80 -- Switch on
+- M81 -- Switch off
+- TOPIC: Name of the device to be switched (same as in the Tasmota device)
+- RELAY#: Number of the relay to be switched. Leave it empty for single relay units.
+
+This can be included either in the slicer settings to be added in front resp. at the end of a gcode file. Or in Octoprint itself, under `Settings->Printer->GCODE scripts` in the fields `Before print job starts` and `After print job completes`. 
+
+Examples:
+
+* `M80 sonoff_printer` To turn a single-relay Tasmota unit named "sonoff_printer" on.
+* `M81 4chpro_printer 1`  Turn off relay number 1 of a multiple relay Tasmota device named "4chpro_printer". 	
 
 ## Screenshots
 


### PR DESCRIPTION
More detailed explanations of the parameters and the GCODE usage.

This patch gives a more detailed explanation of all possible parameters which can be set in the settings dialog. It also explains the usage of the GCODE commands, as they were formally wrongly described. It should not be the IP but the name of the Tasmota device. Which makes sense in the realms of MQTT, which deals not with IPs but with TOPIC names.
Please read carefully, as I am not sure, I got all this right based on reading the source code.
Hope this helps to get this great plugin more users.