### PR TITLE
Off on Error

### DIFF
--- a/octoprint_tasmota_mqtt/__init__.py
+++ b/octoprint_tasmota_mqtt/__init__.py
@@ -244,9 +244,10 @@ class TasmotaMQTTPlugin(octoprint.plugin.SettingsPlugin,
 
 		# Print Error Event
 		if event == Events.ERROR:
-			self._tasmota_mqtt_logger.debug("Powering off enabled plugs.")
+			self._tasmota_mqtt_logger.debug("Powering off enabled plugs because there was an error.")
 			for relay in self._settings.get(['arrRelays']):
-				self.turn_off(relay)
+				if relay.get("errorEvent", True):
+					self.turn_off(relay)
 				
 		# Timeplapse Events
 		if self.powerOffWhenIdle == True and event == Events.MOVIE_RENDERING:

--- a/octoprint_tasmota_mqtt/__init__.py
+++ b/octoprint_tasmota_mqtt/__init__.py
@@ -101,7 +101,7 @@ class TasmotaMQTTPlugin(octoprint.plugin.SettingsPlugin,
 		)
 
 	def get_settings_version(self):
-		return 3
+		return 4
 
 	def on_settings_migrate(self, target, current=None):
 		if current is None or current < 3:
@@ -114,7 +114,15 @@ class TasmotaMQTTPlugin(octoprint.plugin.SettingsPlugin,
 				relay["automaticShutdownEnabled"] = False
 				arrRelays_new.append(relay)
 			self._settings.set(["arrRelays"],arrRelays_new)
-
+			
+		if current <= 3:
+			# Add new fields
+			arrRelays_new = []
+			for relay in self._settings.get(['arrRelays']):
+				relay["errorEvent"] = False
+				arrRelays_new.append(relay)
+			self._settings.set(["arrRelays"],arrRelays_new)
+			
 	def on_settings_save(self, data):
 		old_debug_logging = self._settings.get_boolean(["debug_logging"])
 		old_powerOffWhenIdle = self._settings.get_boolean(["powerOffWhenIdle"])

--- a/octoprint_tasmota_mqtt/__init__.py
+++ b/octoprint_tasmota_mqtt/__init__.py
@@ -246,7 +246,7 @@ class TasmotaMQTTPlugin(octoprint.plugin.SettingsPlugin,
 		if event == Events.ERROR:
 			self._tasmota_mqtt_logger.debug("Powering off enabled plugs because there was an error.")
 			for relay in self._settings.get(['arrRelays']):
-				if relay.get("errorEvent", True):
+				if relay.get("errorEvent", False):
 					self.turn_off(relay)
 				
 		# Timeplapse Events

--- a/octoprint_tasmota_mqtt/__init__.py
+++ b/octoprint_tasmota_mqtt/__init__.py
@@ -234,6 +234,12 @@ class TasmotaMQTTPlugin(octoprint.plugin.SettingsPlugin,
 			self._timeout_value = None
 			self._plugin_manager.send_plugin_message(self._identifier, dict(powerOffWhenIdle=self.powerOffWhenIdle, type="timeout", timeout_value=self._timeout_value))
 
+		# Print Error Event
+		if event == Events.ERROR:
+			self._tasmota_mqtt_logger.debug("Powering off enabled plugs.")
+			for relay in self._settings.get(['arrRelays']):
+				self.turn_off(relay)
+				
 		# Timeplapse Events
 		if self.powerOffWhenIdle == True and event == Events.MOVIE_RENDERING:
 			self._tasmota_mqtt_logger.debug("Timelapse generation started: %s" % payload.get("movie_basename", ""))

--- a/octoprint_tasmota_mqtt/static/js/tasmota_mqtt.js
+++ b/octoprint_tasmota_mqtt/static/js/tasmota_mqtt.js
@@ -236,6 +236,7 @@ $(function() {
 								'automaticShutdownEnabled':ko.observable(false),
 								'warn':ko.observable(true),
 								'warnPrinting':ko.observable(true),
+								'errorEvent':ko.observable(false),
 								'gcode':ko.observable(false),
 								'gcodeOnDelay':ko.observable(0),
 								'gcodeOffDelay':ko.observable(0),

--- a/octoprint_tasmota_mqtt/templates/tasmota_mqtt_settings.jinja2
+++ b/octoprint_tasmota_mqtt/templates/tasmota_mqtt_settings.jinja2
@@ -16,6 +16,7 @@
 				<i class="icon" data-bind="css: {'icon-check': warnPrinting(),'icon-check-empty': !warnPrinting()}" title="Warn While Printing" />
 				<i class="icon" data-bind="css: {'icon-check': connect(),'icon-check-empty': !connect()}" title="Auto Connect" />
 				<i class="icon" data-bind="css: {'icon-check': disconnect(),'icon-check-empty': !disconnect()}" title="Auto Disconnect" />
+				<i class="icon" data-bind="css: {'icon-check': errorEvent(),'icon-check-empty': !errorEvent()}" title="Off on Error" />
 				<i class="icon" data-bind="css: {'icon-check': gcode(),'icon-check-empty': !gcode()}" title="GCODE Trigger" />
 				<i class="icon" data-bind="css: {'icon-check': sysCmdOn(),'icon-check-empty': !sysCmdOn()}" title="Run System Command On" />
 				<i class="icon" data-bind="css: {'icon-check': sysCmdOff(),'icon-check-empty': !sysCmdOff()}" title="Run System Command Off" /></td>
@@ -106,6 +107,7 @@
 			<tr>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: connect"/> Auto Connect</label><input type="text" data-bind="value: connectOnDelay,visible: connect" class="input input-small" /></div></td>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: disconnect"/> Auto Disconnect</label><input type="text" data-bind="value: disconnectOffDelay,visible: disconnect" class="input input-small" /></div></td>
+				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: errorEvent"/> Off on Error</label></div></td>
 			</tr>
 			<tr>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: gcode"/> GCODE Trigger</label></div></td>


### PR DESCRIPTION
This change adds a new feature which enables the device to be turned off on a print error. Octoprint only throws an error event if it is unrecoverable so this will not cause possible problems with a print that could successfully complete.

A possible use for this, and the reason for creating the feature, is a Marlin detected thermal runaway. This turns the beeper on constantly to alert the user. If this beeper is not desirable then the user can turn on this feature.

Such a printer halt requires a power cycle of the printer anyway.