### PR TITLE
only start idle timer if there are any relays that are on

### DIFF
--- a/octoprint_tasmota_mqtt/__init__.py
+++ b/octoprint_tasmota_mqtt/__init__.py
@@ -403,7 +403,7 @@ class TasmotaMQTTPlugin(octoprint.plugin.SettingsPlugin,
 	def _start_idle_timer(self):
 		self._stop_idle_timer()
 
-		if self.powerOffWhenIdle:
+		if self.powerOffWhenIdle and any(map(lambda r: r["currentstate"] == "ON", self._settings.get(["arrRelays"]))):
 			self._idleTimer = ResettableTimer(self.idleTimeout * 60, self._idle_poweroff)
 			self._idleTimer.start()
 


### PR DESCRIPTION
Fixes https://github.com/jneilliii/OctoPrint-TasmotaMQTT/issues/43. Works for me. Let me know if there are problems with it.