### PR TITLE
0.3.9

### DIFF
--- a/octoprint_tasmota_mqtt/__init__.py
+++ b/octoprint_tasmota_mqtt/__init__.py
@@ -13,6 +13,7 @@ import time
 import os
 import re
 import logging
+import json
 
 try:
 	from octoprint.util import ResettableTimer
@@ -107,11 +108,12 @@ class TasmotaMQTTPlugin(octoprint.plugin.SettingsPlugin,
 			idleTimeout = 30,
 			idleIgnoreCommands = 'M105',
 			idleTimeoutWaitTemp = 50,
-			debug_logging = False
+			debug_logging = False,
+			show_sidebar = True
 		)
 
 	def get_settings_version(self):
-		return 5
+		return 6
 
 	def on_settings_migrate(self, target, current=None):
 		if current is None or current < 3:
@@ -139,6 +141,17 @@ class TasmotaMQTTPlugin(octoprint.plugin.SettingsPlugin,
 			for relay in self._settings.get(['arrRelays']):
 				relay["event_on_upload"] = False
 				relay["event_on_startup"] = False
+				arrRelays_new.append(relay)
+			self._settings.set(["arrRelays"], arrRelays_new)
+
+		if current <= 5:
+			# Add new fields
+			arrRelays_new = []
+			for relay in self._settings.get(['arrRelays']):
+				relay["event_on_connect"] = False
+				relay["event_on_disconnect"] = False
+				relay["disconnectAutoOffDelay"] = 30
+				relay["showInNavbar"] = True
 				arrRelays_new.append(relay)
 			self._settings.set(["arrRelays"], arrRelays_new)
 
@@ -259,12 +272,12 @@ class TasmotaMQTTPlugin(octoprint.plugin.SettingsPlugin,
 				self._plugin_manager.send_plugin_message(self._identifier, dict(noMQTT=True))
 
 		# Client Opened Event
-		if event == Events.CLIENT_OPENED:
+		elif event == Events.CLIENT_OPENED:
 			self._plugin_manager.send_plugin_message(self._identifier, dict(powerOffWhenIdle=self.powerOffWhenIdle, type="timeout", timeout_value=self._timeout_value))
 			return
 
 		# Print Started Event
-		if event == Events.PRINT_STARTED and self.powerOffWhenIdle == True:
+		elif event == Events.PRINT_STARTED and self.powerOffWhenIdle == True:
 			if self._abort_timer is not None:
 				self._abort_timer.cancel()
 				self._abort_timer = None
@@ -275,29 +288,44 @@ class TasmotaMQTTPlugin(octoprint.plugin.SettingsPlugin,
 			self._plugin_manager.send_plugin_message(self._identifier, dict(powerOffWhenIdle=self.powerOffWhenIdle, type="timeout", timeout_value=self._timeout_value))
 
 		# Print Error Event
-		if event == Events.ERROR:
+		elif event == Events.ERROR:
 			self._tasmota_mqtt_logger.debug("Powering off enabled plugs because there was an error.")
 			for relay in self._settings.get(['arrRelays']):
 				if relay.get("errorEvent", False):
 					self.turn_off(relay)
 
 		# Timeplapse Events
-		if self.powerOffWhenIdle == True and event == Events.MOVIE_RENDERING:
+		elif self.powerOffWhenIdle == True and event == Events.MOVIE_RENDERING:
 			self._tasmota_mqtt_logger.debug("Timelapse generation started: %s" % payload.get("movie_basename", ""))
 			self._timelapse_active = True
 
-		if self._timelapse_active and event == Events.MOVIE_DONE or event == Events.MOVIE_FAILED:
+		elif self._timelapse_active and event == Events.MOVIE_DONE or event == Events.MOVIE_FAILED:
 			self._tasmota_mqtt_logger.debug("Timelapse generation finished: %s. Return Code: %s" % (payload.get("movie_basename", ""), payload.get("returncode", "completed")))
 			self._timelapse_active = False
 
 		# Printer Connected Event
-		if event == Events.CONNECTED:
+		elif event == Events.CONNECTED:
 			if self._autostart_file:
 				self._tasmota_mqtt_logger.debug("printer connected starting print of %s" % self._autostart_file)
 				self._printer.select_file(self._autostart_file, False, printAfterSelect=True)
 				self._autostart_file = None
+        
+		# Printer Connecting event
+		elif event == Events.CONNECTING:
+			for relay in self._settings.get(["arrRelays"]):
+				if relay["event_on_connect"] is True and not self._printer.is_ready():
+					self._tasmota_mqtt_logger.debug("powering on {} due to connection attempt.".format(relay["topic"]))
+					self.turn_on(relay)
+		# Printer Disconnected event
+		elif event == Events.DISCONNECTED:
+			for relay in self._settings.get(["arrRelays"]):
+				# ToDo: add condition to Settings...
+				if relay["currentstate"] == "ON" and relay["event_on_disconnect"] is True:
+					self._tasmota_mqtt_logger.debug("powering off {} after {} due to disconnect event.".format(relay["topic"],int(relay["disconnectAutoOffDelay"])))
+					t = threading.Timer(int(relay["disconnectAutoOffDelay"]),self.turn_off,[relay])
+					t.start()
 		# File Uploaded Event
-		if event == Events.UPLOAD and any(map(lambda r: r["event_on_upload"] == True, self._settings.get(["arrRelays"]))):
+		elif event == Events.UPLOAD and any(map(lambda r: r["event_on_upload"] == True, self._settings.get(["arrRelays"]))):
 			if payload.get("print", False):  # implemented in OctoPrint version 1.4.1
 				self._tasmota_mqtt_logger.debug(
 					"File uploaded: %s. Turning enabled relays on." % payload.get("name", ""))
@@ -324,7 +352,7 @@ class TasmotaMQTTPlugin(octoprint.plugin.SettingsPlugin,
 		return [
 			dict(type="navbar", custom_bindings=True),
 			dict(type="settings", custom_bindings=True),
-			dict(type="sidebar", icon="plug", custom_bindings=True, data_bind="visible: filteredSmartplugs().length > 0", template="tasmota_mqtt_sidebar.jinja2", template_header="tasmota_mqtt_sidebar_header.jinja2")
+			dict(type="sidebar", icon="plug", custom_bindings=True, data_bind="visible: filteredSmartplugs().length > 0 && settingsViewModel.settings.plugins.tasmota_mqtt.show_sidebar()", template="tasmota_mqtt_sidebar.jinja2", template_header="tasmota_mqtt_sidebar_header.jinja2")
 		]
 
 	##~~ SimpleApiPlugin mixin
@@ -339,7 +367,8 @@ class TasmotaMQTTPlugin(octoprint.plugin.SettingsPlugin,
 			removeRelay=["topic", "relayN"],
 			enableAutomaticShutdown=[],
 			disableAutomaticShutdown=[],
-			abortAutomaticShutdown=[])
+			abortAutomaticShutdown=[],
+			getListPlug=[])
 
 	def on_api_command(self, command, data):
 		if not Permissions.PLUGIN_TASMOTA_MQTT_CONTROL.can():
@@ -406,6 +435,9 @@ class TasmotaMQTTPlugin(octoprint.plugin.SettingsPlugin,
 
 		if command == "enableAutomaticShutdown" or command == "disableAutomaticShutdown" or command == "abortAutomaticShutdown":
 			self._plugin_manager.send_plugin_message(self._identifier, dict(powerOffWhenIdle=self.powerOffWhenIdle, type="timeout", timeout_value=self._timeout_value))
+
+		if command == "getListPlug":
+			return json.dumps(self._settings.get(["arrRelays"]))
 
 	def turn_on(self, relay):
 		self.mqtt_publish(self.generate_mqtt_full_topic(relay, "cmnd"), "ON")

--- a/octoprint_tasmota_mqtt/__init__.py
+++ b/octoprint_tasmota_mqtt/__init__.py
@@ -113,7 +113,7 @@ class TasmotaMQTTPlugin(octoprint.plugin.SettingsPlugin,
 		)
 
 	def get_settings_version(self):
-		return 6
+		return 7
 
 	def on_settings_migrate(self, target, current=None):
 		if current is None or current < 3:
@@ -152,6 +152,14 @@ class TasmotaMQTTPlugin(octoprint.plugin.SettingsPlugin,
 				relay["event_on_disconnect"] = False
 				relay["disconnectAutoOffDelay"] = 30
 				relay["showInNavbar"] = True
+				arrRelays_new.append(relay)
+			self._settings.set(["arrRelays"], arrRelays_new)
+
+		if current <= 6:
+			# Add new fields
+			arrRelays_new = []
+			for relay in self._settings.get(['arrRelays']):
+				relay["label"] = ""
 				arrRelays_new.append(relay)
 			self._settings.set(["arrRelays"], arrRelays_new)
 
@@ -469,7 +477,7 @@ class TasmotaMQTTPlugin(octoprint.plugin.SettingsPlugin,
 			self._tasmota_mqtt_logger.debug("@ command received parameters: {}".format(parameters))
 			if len(parameters) >= 3:
 				for relay in self._settings.get(["arrRelays"]):
-					if relay["topic"].upper() == parameters[0].upper() and relay["relayN"] == parameters[1]:
+					if relay["topic"].upper() == parameters[0].upper() and parameters[1] in [relay["relayN"], "0"]:
 						if parameters[2] == "ON":
 							self.turn_on(relay)
 						if parameters[2] == "OFF":

--- a/octoprint_tasmota_mqtt/static/js/tasmota_mqtt.js
+++ b/octoprint_tasmota_mqtt/static/js/tasmota_mqtt.js
@@ -257,7 +257,8 @@ $(function() {
 								'event_on_startup':ko.observable(false),
 								'event_on_connect':ko.observable(false),
 								'event_on_disconnect':ko.observable(false),
-                                'label': ko.observable('')} );
+                                'label': ko.observable(''),
+                                'invertedLogic': ko.observable(false)} );
 			self.settingsViewModel.settings.plugins.tasmota_mqtt.arrRelays.push(self.selectedRelay());
 			$("#TasmotaMQTTRelayEditor").modal("show");
 		}

--- a/octoprint_tasmota_mqtt/static/js/tasmota_mqtt.js
+++ b/octoprint_tasmota_mqtt/static/js/tasmota_mqtt.js
@@ -22,7 +22,7 @@ $(function() {
 					});
 		});
 		self.show_sidebar = ko.computed(function(){
-			return self.filteredSmartplugs().length > 0;
+			return self.filteredSmartplugs().length > 0 && self.settingsViewModel.settings.plugins.tasmota_mqtt.show_sidebar();
 		});
 		self.toggleShutdownTitle = ko.pureComputed(function() {
 			return self.automaticShutdownEnabled() ? 'Disable Automatic Power Off' : 'Enable Automatic Power Off';
@@ -233,6 +233,7 @@ $(function() {
 			self.selectedRelay( {'topic':ko.observable('sonoff'),
 								'relayN':ko.observable(''),
 								'icon':ko.observable('icon-bolt'),
+								'showInNavbar':ko.observable(true),
 								'automaticShutdownEnabled':ko.observable(false),
 								'warn':ko.observable(true),
 								'warnPrinting':ko.observable(true),
@@ -242,6 +243,7 @@ $(function() {
 								'gcodeOffDelay':ko.observable(0),
 								'connect':ko.observable(false),
 								'connectOnDelay':ko.observable(15),
+								'disconnectAutoOffDelay':ko.observable(30),
 								'disconnect':ko.observable(false),
 								'disconnectOffDelay':ko.observable(0),
 								'sysCmdOn':ko.observable(false),
@@ -252,7 +254,9 @@ $(function() {
 								'sysCmdOffDelay':ko.observable(0),
 								'currentstate':ko.observable('UNKNOWN'),
 								'event_on_upload':ko.observable(false),
-								'event_on_startup':ko.observable(false)} );
+								'event_on_startup':ko.observable(false),
+								'event_on_connect':ko.observable(false),
+								'event_on_disconnect':ko.observable(false)} );
 			self.settingsViewModel.settings.plugins.tasmota_mqtt.arrRelays.push(self.selectedRelay());
 			$("#TasmotaMQTTRelayEditor").modal("show");
 		}

--- a/octoprint_tasmota_mqtt/static/js/tasmota_mqtt.js
+++ b/octoprint_tasmota_mqtt/static/js/tasmota_mqtt.js
@@ -147,7 +147,7 @@ $(function() {
 							hide: false
 							});
 				return;
-			} 
+			}
 			if (data.hasOwnProperty("powerOffWhenIdle")) {
 				self.settingsViewModel.settings.plugins.tasmota_mqtt.powerOffWhenIdle(data.powerOffWhenIdle);
 
@@ -168,7 +168,7 @@ $(function() {
 					}
 				}
 				return;
-			} 
+			}
 			if (data.hasOwnProperty("topic")) {
 				var relay = ko.utils.arrayFirst(self.settingsViewModel.settings.plugins.tasmota_mqtt.arrRelays(),function(item){
 					return (item.topic() == data.topic) && (item.relayN() == data.relayN);
@@ -256,7 +256,8 @@ $(function() {
 								'event_on_upload':ko.observable(false),
 								'event_on_startup':ko.observable(false),
 								'event_on_connect':ko.observable(false),
-								'event_on_disconnect':ko.observable(false)} );
+								'event_on_disconnect':ko.observable(false),
+                                'label': ko.observable('')} );
 			self.settingsViewModel.settings.plugins.tasmota_mqtt.arrRelays.push(self.selectedRelay());
 			$("#TasmotaMQTTRelayEditor").modal("show");
 		}

--- a/octoprint_tasmota_mqtt/templates/tasmota_mqtt_navbar.jinja2
+++ b/octoprint_tasmota_mqtt/templates/tasmota_mqtt_navbar.jinja2
@@ -1,5 +1,5 @@
 <!-- ko foreach: settingsViewModel.settings.plugins.tasmota_mqtt.arrRelays -->
-<a class="pull-right" href=#" data-bind='visible: $root.loginStateViewModel.loggedIn(), click: $root.relayClick,  attr: {title: (topic()+"|"+relayN())}' style="display: none;float: left;"><i class="icon" data-bind="css: [currentstate(), icon(),(($root.processing().indexOf(topic() + '|' + relayN()) > -1) ? 'icon-spin' : '')].join(' ')"></i></a>
+<a class="pull-right" href=#" data-bind='visible: $root.loginStateViewModel.loggedIn() && showInNavbar(), click: $root.relayClick,  attr: {title: (topic()+"|"+relayN())}' style="display: none;float: left;"><i class="icon" data-bind="css: [currentstate(), icon(),(($root.processing().indexOf(topic() + '|' + relayN()) > -1) ? 'icon-spin' : '')].join(' ')"></i></a>
 <!-- /ko -->
 <div id="TasmotaMQTTWarning" data-bind="with: selectedRelay" class="modal hide fade">
     <div class="modal-header">

--- a/octoprint_tasmota_mqtt/templates/tasmota_mqtt_navbar.jinja2
+++ b/octoprint_tasmota_mqtt/templates/tasmota_mqtt_navbar.jinja2
@@ -1,5 +1,5 @@
 <!-- ko foreach: settingsViewModel.settings.plugins.tasmota_mqtt.arrRelays -->
-<a class="pull-right" href=#" data-bind='visible: $root.loginStateViewModel.loggedIn() && showInNavbar(), click: $root.relayClick,  attr: {title: (topic()+(relayN() ? "|"+relayN() : ""))}' style="display: none;float: left;"><i class="icon" data-bind="css: [currentstate(), icon(),(($root.processing().indexOf(topic() + '|' + relayN()) > -1) ? 'icon-spin' : '')].join(' ')"></i></a>
+<a class="pull-right" href=#" data-bind='visible: $root.loginStateViewModel.loggedIn() && showInNavbar(), click: $root.relayClick,  attr: {title: (label().length > 0 ? label() : topic()+(relayN() ? "|"+relayN() : ""))}' style="display: none;float: left;"><i class="icon" data-bind="css: [currentstate(), icon(),(($root.processing().indexOf(topic() + '|' + relayN()) > -1) ? 'icon-spin' : '')].join(' ')"></i></a>
 <!-- /ko -->
 <div id="TasmotaMQTTWarning" data-bind="with: selectedRelay" class="modal hide fade">
     <div class="modal-header">
@@ -8,7 +8,7 @@
     </div>
     <div class="modal-body">
         <p>
-            <!--ko text: (topic()+(relayN() ? "|"+relayN() : ""))--><!--/ko--> is currently <!--ko text: currentstate()--><!--/ko-->.
+            <!--ko text: (label().length > 0 ? label() : topic()+(relayN() ? "|"+relayN() : ""))--><!--/ko--> is currently <!--ko text: currentstate()--><!--/ko-->.
         </p>
 		<p>
             {{ _('Are you sure you want to proceed?') }}

--- a/octoprint_tasmota_mqtt/templates/tasmota_mqtt_navbar.jinja2
+++ b/octoprint_tasmota_mqtt/templates/tasmota_mqtt_navbar.jinja2
@@ -1,5 +1,5 @@
 <!-- ko foreach: settingsViewModel.settings.plugins.tasmota_mqtt.arrRelays -->
-<a class="pull-right" href=#" data-bind='visible: $root.loginStateViewModel.loggedIn() && showInNavbar(), click: $root.relayClick,  attr: {title: (topic()+"|"+relayN())}' style="display: none;float: left;"><i class="icon" data-bind="css: [currentstate(), icon(),(($root.processing().indexOf(topic() + '|' + relayN()) > -1) ? 'icon-spin' : '')].join(' ')"></i></a>
+<a class="pull-right" href=#" data-bind='visible: $root.loginStateViewModel.loggedIn() && showInNavbar(), click: $root.relayClick,  attr: {title: (topic()+(relayN() ? "|"+relayN() : ""))}' style="display: none;float: left;"><i class="icon" data-bind="css: [currentstate(), icon(),(($root.processing().indexOf(topic() + '|' + relayN()) > -1) ? 'icon-spin' : '')].join(' ')"></i></a>
 <!-- /ko -->
 <div id="TasmotaMQTTWarning" data-bind="with: selectedRelay" class="modal hide fade">
     <div class="modal-header">
@@ -8,7 +8,7 @@
     </div>
     <div class="modal-body">
         <p>
-            <!--ko text: topic()--><!--/ko-->|<!--ko text: relayN()--><!--/ko--> is currently <!--ko text: currentstate()--><!--/ko-->. 
+            <!--ko text: (topic()+(relayN() ? "|"+relayN() : ""))--><!--/ko--> is currently <!--ko text: currentstate()--><!--/ko-->.
         </p>
 		<p>
             {{ _('Are you sure you want to proceed?') }}

--- a/octoprint_tasmota_mqtt/templates/tasmota_mqtt_settings.jinja2
+++ b/octoprint_tasmota_mqtt/templates/tasmota_mqtt_settings.jinja2
@@ -102,14 +102,13 @@
 	<div class="modal-body">
 		<table class="table table-condensed">
 			<tr>
-				<td><div class="controls"><label class="control-label">Topic</label><input type="text" class="input-block-level" data-bind="value: topic" /><div></td>
+				<td><div class="controls"><label class="control-label">Topic</label><input type="text" class="input-block-level" data-bind="value: topic" /></div></td>
 				<td><div class="controls"><label class="control-label">Relay #</label><input type="text" class="input input-small" data-bind="value: relayN" /></div></td>
-				<td><div class="controls"><label class="control-label">Icon Class</label><input type="text" class="input-block-level" data-bind="value: icon, iconpicker: icon,iconpickerOptions: {hideOnSelect: true, collision: true}" /><div></td>
-			</tr>
+				<td><div class="controls"><label class="control-label">Icon Class</label><input type="text" class="input-block-level" data-bind="value: icon, iconpicker: icon,iconpickerOptions: {hideOnSelect: true, collision: true}" /></div></td>
+			    <td><div class="controls"><label class="control-label">Label</label><input type="text" class="input-block-level" data-bind="value: label" /></div></td>
+            </tr>
 			<tr>
-				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: showInNavbar"/> Show in Navbar</label></div></td>
-			</tr>
-			<tr>
+                <td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: showInNavbar"/> Show in Navbar</label></div></td>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: event_on_upload"/> On With Upload Event</label></div></td>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: event_on_startup"/> On With Startup Event</label></div></td>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: event_on_connect"/> On With Connecting Event</label></div></td>

--- a/octoprint_tasmota_mqtt/templates/tasmota_mqtt_settings.jinja2
+++ b/octoprint_tasmota_mqtt/templates/tasmota_mqtt_settings.jinja2
@@ -117,6 +117,7 @@
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: automaticShutdownEnabled, enable: $root.settingsViewModel.settings.plugins.tasmota_mqtt.powerOffWhenIdle()" disabled /> Off on Idle</label></div></td>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: warn"/> Warning Prompt</label></div></td>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: warnPrinting"/> Warn While Printing</label></div></td>
+				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: invertedLogic"/> Inverted Logic</label></div></td>
 			</tr>
 			<tr>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: connect"/> Auto Connect</label><input type="text" data-bind="value: connectOnDelay,visible: connect" class="input input-small" /></div></td>

--- a/octoprint_tasmota_mqtt/templates/tasmota_mqtt_settings.jinja2
+++ b/octoprint_tasmota_mqtt/templates/tasmota_mqtt_settings.jinja2
@@ -46,6 +46,13 @@
 		</div>
 	</div>
 	<div class="control-group">
+		<div class="controls">
+			<label class="checkbox">
+			<input type="checkbox" title="Show TasmotaMQTT sidebar entry" data-bind="checked: settingsViewModel.settings.plugins.tasmota_mqtt.show_sidebar, enable: settingsViewModel.settings.plugins.tasmota_mqtt.powerOffWhenIdle()" disabled />Show Sidebar
+			</label>
+		</div>
+	</div>
+	<div class="control-group">
 		<label class="control-label">Abort Power Off Timeout</label>
 		<div class="controls">
 			<div class="input-append" title="Pop up will be displayed for this amount of time to allow for cancelling power off of plugs.">
@@ -100,9 +107,12 @@
 				<td><div class="controls"><label class="control-label">Icon Class</label><input type="text" class="input-block-level" data-bind="value: icon, iconpicker: icon,iconpickerOptions: {hideOnSelect: true, collision: true}" /><div></td>
 			</tr>
 			<tr>
+				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: showInNavbar"/> Show in Navbar</label></div></td>
+			</tr>
+			<tr>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: event_on_upload"/> On With Upload Event</label></div></td>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: event_on_startup"/> On With Startup Event</label></div></td>
-				<td></td>
+				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: event_on_connect"/> On With Connecting Event</label></div></td>
 			</tr>
 			<tr>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: automaticShutdownEnabled, enable: $root.settingsViewModel.settings.plugins.tasmota_mqtt.powerOffWhenIdle()" disabled /> Off on Idle</label></div></td>
@@ -113,6 +123,9 @@
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: connect"/> Auto Connect</label><input type="text" data-bind="value: connectOnDelay,visible: connect" class="input input-small" /></div></td>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: disconnect"/> Auto Disconnect</label><input type="text" data-bind="value: disconnectOffDelay,visible: disconnect" class="input input-small" /></div></td>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: errorEvent"/> Off on Error</label></div></td>
+			</tr>
+			<tr>
+				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: event_on_disconnect"/> Auto off after disconnect</label><input type="text" data-bind="value: disconnectAutoOffDelay,visible: event_on_disconnect" class="input input-small" /></div></td>
 			</tr>
 			<tr>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: gcode"/> GCODE Trigger</label></div></td>

--- a/octoprint_tasmota_mqtt/templates/tasmota_mqtt_sidebar_header.jinja2
+++ b/octoprint_tasmota_mqtt/templates/tasmota_mqtt_sidebar_header.jinja2
@@ -1,3 +1,3 @@
-<div class="accordion-heading-button btn-group" data-bind="visible: loginStateViewModel.loggedIn()">
+<div class="accordion-heading-button btn-group" data-bind="visible: loginStateViewModel.loggedIn() && settingsViewModel.settings.plugins.tasmota_mqtt.show_sidebar()">
 	<a href="#" data-bind="enable: loginStateViewModel.loggedIn(), click: onToggleAutomaticShutdown, attr: {title: toggleShutdownTitle()}, css: {'fa-toggle-off' : !settingsViewModel.settings.plugins.tasmota_mqtt.powerOffWhenIdle(), 'fa-toggle-on' : settingsViewModel.settings.plugins.tasmota_mqtt.powerOffWhenIdle()}" title="Enable Automatic Power Off" class="fa fa-lg fa-toggle-off"></a>
 </div>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota_mqtt"
 plugin_name = "OctoPrint-TasmotaMQTT"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.3.8"
+plugin_version = "0.3.9rc1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota_mqtt"
 plugin_name = "OctoPrint-TasmotaMQTT"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.3.9rc4"
+plugin_version = "0.3.9rc5"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota_mqtt"
 plugin_name = "OctoPrint-TasmotaMQTT"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.3.9rc2"
+plugin_version = "0.3.9rc3"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota_mqtt"
 plugin_name = "OctoPrint-TasmotaMQTT"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.3.9rc1"
+plugin_version = "0.3.9rc2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota_mqtt"
 plugin_name = "OctoPrint-TasmotaMQTT"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.3.9rc5"
+plugin_version = "0.3.9"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tasmota_mqtt"
 plugin_name = "OctoPrint-TasmotaMQTT"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.3.9rc3"
+plugin_version = "0.3.9rc4"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
* Auto on on connect attempt and off on disconnect
* Added configuration settings for on/off on (dis)connect
* Added configurable UI entities for Sidebar and Navbar
* Remove `|` when not in use, resolves #59
* Added label option to relay for title hover and warning prompts, resolves #61.
* Added inverted logic option for relays for specific normally closed devices, resolves #17 
* Added custom @ command TASMOTAMQTT to allow for controlling devices via gcode without effecting M81 for printers that support that, resolves #62, resolves #37. Includes support for both OFF and ON commands to be sent. 

In order to use the command you would use `@TASMOTAMQTT <topic> <relay#> <ON | OFF>`, for example for the setting below the command would be `@TASMOTAMQTT living_room 4 OFF` to power off the relay and `@TASMOTAMQTT living_room 4 ON` to power on the relay.

![](https://github.com/jneilliii/OctoPrint-TasmotaMQTT/raw/master/relay_editor.png)